### PR TITLE
improve getDiscretizedBins handling dates

### DIFF
--- a/R/class-Bin.R
+++ b/R/class-Bin.R
@@ -16,9 +16,6 @@ check_bin_range <- function(object) {
     } else {
       if (!any(is.na(c(start, end))) && any(is.na(suppressWarnings(as.numeric(c(start, end)))))) {
         msg <- "Must provide binStart and binEnds which are coercible to numeric."
-        print("The offending binStart and binEnd:")
-        print(start)
-        print(end)
         errors <- c(errors, msg)
       } else {
         if (!any(is.na(c(start, end))) && as.numeric(start) > as.numeric(end)) {

--- a/R/class-Bin.R
+++ b/R/class-Bin.R
@@ -16,6 +16,9 @@ check_bin_range <- function(object) {
     } else {
       if (!any(is.na(c(start, end))) && any(is.na(suppressWarnings(as.numeric(c(start, end)))))) {
         msg <- "Must provide binStart and binEnds which are coercible to numeric."
+        print("The offending binStart and binEnd:")
+        print(start)
+        print(end)
         errors <- c(errors, msg)
       } else {
         if (!any(is.na(c(start, end))) && as.numeric(start) > as.numeric(end)) {

--- a/R/utils-numeric.R
+++ b/R/utils-numeric.R
@@ -27,7 +27,7 @@ getDiscretizedBins <- function(x, method = c('equalInterval', 'quantile', 'sd'),
   }
 
   if (isDate) {
-    binEdges <- as.Date(binEdges, origin = "1970-01-01")
+    binEdges <- as.Date(binEdges, origin = "1970-01-01")  # Origin matches as.numeric default origin
   }
 
   binStarts <- binEdges[1:(length(binEdges)-1)]

--- a/R/utils-numeric.R
+++ b/R/utils-numeric.R
@@ -36,15 +36,25 @@ getDiscretizedBins <- function(x, method = c('equalInterval', 'quantile', 'sd'),
 
   # only format human-friendly labels. binStarts and binEnds should provide exact values
   # must also guarantee that the first binStart and last binEnd encompass the full data range even after formatting
-  formattedBinStarts <- formatC(binStarts)
+  if (isDate) {
+    # Dates are already human-friendly.
+    formattedBinStarts <- binStarts
+    formattedBinEnds <- binEnds
+  } else {
+    formattedBinStarts <- formatC(binStarts)
+    formattedBinEnds <- formatC(binEnds)
+  }
   # think the alternative is to write a recursive fxn to call formatC w more digits until we get a result we like. 
   # that seems costly, so ill wait to do that until we see how much an issue this really is
-  if (as.numeric(formattedBinStarts[[1]]) > binStarts[[1]]) formattedBinStarts[[1]] <- as.character(binStarts[[1]])
-  formattedBinEnds <- formatC(binEnds)
-  if (as.numeric(formattedBinEnds[[length(binEnds)]]) < binEnds[[length(binEnds)]]) formattedBinEnds[[length(binEnds)]] <- as.character(binEnds[[length(binEnds)]])
+  if (as.numeric(formattedBinStarts[[1]]) > as.numeric(binStarts[[1]])) formattedBinStarts[[1]] <- as.character(binStarts[[1]])
+  if (as.numeric(formattedBinEnds[[length(binEnds)]]) < as.numeric(binEnds[[length(binEnds)]])) formattedBinEnds[[length(binEnds)]] <- as.character(binEnds[[length(binEnds)]])
 
   binLabels <- paste0("(",formattedBinStarts,", ", formattedBinEnds, "]")
   binLabels[[1]] <- gsub("(","[",binLabels[[1]], fixed=T)
+
+  # if (isDate) {
+  #   formattedBinEnds <- as.Date(as.numeric(formattedBinEnds), origin = "1900-01-01")
+  # }
 
   if (getValue) {
     if (length(binEdges) == 1) {
@@ -56,8 +66,8 @@ getDiscretizedBins <- function(x, method = c('equalInterval', 'quantile', 'sd'),
     values <- rep(NA_real_, length(binStarts))
   }
   
-  bins <- lapply(1:length(binStarts), FUN = function(x) { Bin(binStart = as.character(binStarts[[x]]),
-                                                              binEnd = as.character(binEnds[[x]]),
+  bins <- lapply(1:length(binStarts), FUN = function(x) { Bin(binStart = binStarts[[x]],
+                                                              binEnd = binEnds[[x]],
                                                               binLabel = binLabels[[x]],
                                                               value = values[[x]])})
 

--- a/R/utils-numeric.R
+++ b/R/utils-numeric.R
@@ -62,10 +62,21 @@ getDiscretizedBins <- function(x, method = c('equalInterval', 'quantile', 'sd'),
     values <- rep(NA_real_, length(binStarts))
   }
   
-  bins <- lapply(1:length(binStarts), FUN = function(x) { Bin(binStart = binStarts[[x]],
+  # For numeric vars, coerce bin starts and ends to character so as to not lose any precision.
+  # It's possible we wouldnt lose precision regardless, but that's something we can look into in the future.
+  # We don't want to do this for dates, because then we loose the date being a date
+  if (isDate) {
+    bins <- lapply(1:length(binStarts), FUN = function(x) { Bin(binStart = binStarts[[x]],
                                                               binEnd = binEnds[[x]],
                                                               binLabel = binLabels[[x]],
                                                               value = values[[x]])})
+
+  } else {
+    bins <- lapply(1:length(binStarts), FUN = function(x) { Bin(binStart = as.character(binStarts[[x]]),
+                                                              binEnd = as.character(binEnds[[x]]),
+                                                              binLabel = binLabels[[x]],
+                                                              value = values[[x]])})
+  }
 
   return(BinList(S4Vectors::SimpleList(bins)))
 }

--- a/R/utils-numeric.R
+++ b/R/utils-numeric.R
@@ -27,7 +27,7 @@ getDiscretizedBins <- function(x, method = c('equalInterval', 'quantile', 'sd'),
   }
 
   if (isDate) {
-    binEdges <- as.Date(binEdges, origin = "1900-01-01") # this is the default origin
+    binEdges <- as.Date(binEdges, origin = "1970-01-01")
   }
 
   binStarts <- binEdges[1:(length(binEdges)-1)]
@@ -51,10 +51,6 @@ getDiscretizedBins <- function(x, method = c('equalInterval', 'quantile', 'sd'),
 
   binLabels <- paste0("(",formattedBinStarts,", ", formattedBinEnds, "]")
   binLabels[[1]] <- gsub("(","[",binLabels[[1]], fixed=T)
-
-  # if (isDate) {
-  #   formattedBinEnds <- as.Date(as.numeric(formattedBinEnds), origin = "1900-01-01")
-  # }
 
   if (getValue) {
     if (length(binEdges) == 1) {

--- a/tests/testthat/test-utils-numeric.R
+++ b/tests/testthat/test-utils-numeric.R
@@ -22,9 +22,28 @@ test_that("getDiscretizedBins returns sane results", {
 
   dates <- as.Date(c('1999-12-11','1999-06-14','1999-02-26','1999-05-24','1999-02-25','1999-09-06',
                      '1999-07-24','1999-05-29','1999-01-03','1999-06-28','1999-02-13','1999-03-17'))
-  expect_equal(length(getDiscretizedBins(dates)), 10)
+
+  dateBins <- getDiscretizedBins(dates)
+  expect_equal(length(dateBins), 10)
+  expect_equal(strsplit(dateBins[[1]]@binLabel, ', ')[[1]][1], paste0("[",dateBins[[1]]@binStart))
+  expect_equal(strsplit(dateBins[[1]]@binLabel, ', ')[[1]][2], paste0(dateBins[[1]]@binEnd, "]"))
   expect_equal(length(getDiscretizedBins(dates, 'quantile')), 10)
   expect_equal(length(getDiscretizedBins(dates, 'sd')), 5)
+
+  ## different types of dates... 
+  dates <- as.Date(c("1969-06-05T00:00:00", "1969-06-06T00:00:00", "1969-06-07T00:00:00","1969-06-08T00:00:00", "1969-06-09T00:00:00", "1969-06-10T00:00:00",
+              "1969-06-11T00:00:00", "1969-06-12T00:00:00", "1969-06-13T00:00:00",
+              "1969-06-14T00:00:00", "1969-06-15T00:00:00", "1969-06-16T00:00:00",
+              "1969-06-17T00:00:00", "1969-06-18T00:00:00", "1969-06-19T00:00:00",
+              "1969-06-20T00:00:00", "1969-06-21T00:00:00", "1969-06-22T00:00:00",
+              "1969-06-23T00:00:00", "1969-06-24T00:00:00"))
+
+  dateBins <- getDiscretizedBins(dates)
+  expect_equal(length(dateBins), 10)
+  expect_equal(strsplit(dateBins[[1]]@binLabel, ', ')[[1]][1], paste0("[",dateBins[[1]]@binStart))
+  expect_equal(strsplit(dateBins[[1]]@binLabel, ', ')[[1]][2], paste0(dateBins[[1]]@binEnd, "]"))
+  expect_equal(length(getDiscretizedBins(dates, 'quantile')), 10)
+  expect_equal(length(getDiscretizedBins(dates, 'sd')), 4)
 
   ## return as many bins as possible for these cases
   # almost no data

--- a/tests/testthat/test-utils-numeric.R
+++ b/tests/testthat/test-utils-numeric.R
@@ -24,9 +24,14 @@ test_that("getDiscretizedBins returns sane results", {
                      '1999-07-24','1999-05-29','1999-01-03','1999-06-28','1999-02-13','1999-03-17'))
 
   dateBins <- getDiscretizedBins(dates)
+  # Test that the bin labels match the bin starts and ends, as well as that the
+  # dates of bins make sense
   expect_equal(length(dateBins), 10)
   expect_equal(strsplit(dateBins[[1]]@binLabel, ', ')[[1]][1], paste0("[",dateBins[[1]]@binStart))
   expect_equal(strsplit(dateBins[[1]]@binLabel, ', ')[[1]][2], paste0(dateBins[[1]]@binEnd, "]"))
+  expect_equal(dateBins[[1]]@binStart, min(dates))
+  expect_equal(dateBins[[10]]@binEnd, max(dates))
+
   expect_equal(length(getDiscretizedBins(dates, 'quantile')), 10)
   expect_equal(length(getDiscretizedBins(dates, 'sd')), 5)
 
@@ -39,9 +44,14 @@ test_that("getDiscretizedBins returns sane results", {
               "1969-06-23T00:00:00", "1969-06-24T00:00:00"))
 
   dateBins <- getDiscretizedBins(dates)
+  # Test that the bin labels match the bin starts and ends, as well as that the
+  # dates of bins make sense
   expect_equal(length(dateBins), 10)
   expect_equal(strsplit(dateBins[[1]]@binLabel, ', ')[[1]][1], paste0("[",dateBins[[1]]@binStart))
   expect_equal(strsplit(dateBins[[1]]@binLabel, ', ')[[1]][2], paste0(dateBins[[1]]@binEnd, "]"))
+  expect_equal(dateBins[[1]]@binStart, min(dates))
+  expect_equal(dateBins[[10]]@binEnd, max(dates))
+
   expect_equal(length(getDiscretizedBins(dates, 'quantile')), 10)
   expect_equal(length(getDiscretizedBins(dates, 'sd')), 4)
 


### PR DESCRIPTION
Resolves #15 

This PR makes two main changes:
1. Removes dates from passing through `formatC`, since dates are already human readable
2. Changes the origin in `as.Date`.

I also spent some time trying to simplify some of the date logic but that became a bigger rabbit hole than i had expected.

Passed integration test ✅ 