### PR TITLE
Improving megastudy zero imputation

### DIFF
--- a/R/methods-Megastudy.R
+++ b/R/methods-Megastudy.R
@@ -321,7 +321,7 @@ setMethod('getDTWithImputedZeroes', signature = c('Megastudy', 'VariableMetadata
   
   dataTablesOfImputedValues <- lapply(variableSpecsToImputeZeroesFor, makeImputedZeroesDT)
   mergeDTsOfImputedValues <- function(x,y) {
-    merge(x, y, by = c(upstreamEntityIdColNames, varSpecEntityIdColName, weightingVarColName), allow.cartesian=TRUE)
+    merge(x, y, by = c(upstreamEntityIdColNames, varSpecEntityIdColName, weightingVarColName), allow.cartesian=TRUE, all=TRUE)
   }
   .dt2 <- purrr::reduce(dataTablesOfImputedValues, mergeDTsOfImputedValues)
   veupathUtils::logWithTime(paste("Finished collapsing imputed values for all variables into one table. Added", nrow(.dt2), "total rows."), verbose)

--- a/R/methods-Megastudy.R
+++ b/R/methods-Megastudy.R
@@ -227,7 +227,7 @@ setMethod('getDTWithImputedZeroes', signature = c('Megastudy', 'VariableMetadata
   variableColumnNames <- unlist(lapply(as.list(variables), getVariableColumnNames))
   allEntityIdColumns <- object@ancestorIdColumns
   # drop things that arent in the plot, except ids
-  .dt <- .dt[, c(variableColumnNames, allEntityIdColumns), with=FALSE]
+  #.dt <- .dt[, c(variableColumnNames, allEntityIdColumns), with=FALSE]
   vocabs <- object@studySpecificVocabularies
 
   # it seems a lot of this validation could belong to some custom obj w both a megastudy and vm slot.. but what is that? a MegastudyPlot?

--- a/R/methods-Megastudy.R
+++ b/R/methods-Megastudy.R
@@ -242,14 +242,7 @@ setMethod('getDTWithImputedZeroes', signature = c('Megastudy', 'VariableMetadata
   variableMetadataNeedingStudyVocabularies <- findStudyDependentVocabularyVariableMetadata(variables)
   variableSpecsWithStudyVocabs <- findVariableSpecsFromStudyVocabulary(vocabs, variables, "Never")
   variableCollectionSpecsWithStudyVocabs <- findVariableSpecsFromStudyVocabulary(vocabs, variables, "Always")
-  if (is.null(variableCollectionSpecsWithStudyVocabs)) {
-    variableMetadataForStudyVocabVariables <- findVariableMetadataFromVariableSpec(variables, variableSpecsWithStudyVocabs)
-  } else {
-    variableMetadataForStudyVocabVariables <- findVariableMetadataFromVariableSpec(variables, variableCollectionSpecsWithStudyVocabs)
-  }
-  #if (length(variableSpecsWithStudyVocabs) > length(variableMetadataForStudyVocabVariables)) {
-  #  warning("Study vocabularies were provided for variables that are not present in the plot. These will be ignored.")
-  #}
+  variableMetadataForStudyVocabVariables <- findVariableMetadataFromVariableSpec(variables, variableSpecsWithStudyVocabs)
   if (length(variableMetadataForStudyVocabVariables) < length(variableMetadataNeedingStudyVocabularies)) {
     stop("Some provided variables require study vocabularies but dont have one.")
   }

--- a/R/methods-VariableMetadata.R
+++ b/R/methods-VariableMetadata.R
@@ -639,18 +639,19 @@ setGeneric("findVariableMetadataFromVariableSpec",
 
 #' @export
 setMethod("findVariableMetadataFromVariableSpec", signature("VariableMetadataList", "VariableSpecList"), function(variables, object) {
-  variableSpecs <- unlist(lapply(as.list(variables), veupathUtils::getVariableSpec, FALSE))
+  variableSpecs <- unlist(lapply(as.list(variables), veupathUtils::getVariableSpec, "Never"))
   colNamesToMatch <- unlist(lapply(as.list(object), veupathUtils::getColName))
  
   index <- which(purrr::map(variableSpecs, function(x) {veupathUtils::getColName(x)}) %in% colNamesToMatch)
+  
   if (!length(index)) return(NULL)
-
+  
   return(variables[index]) 
 })
 
 #' @export
 setMethod("findVariableMetadataFromVariableSpec", signature("VariableMetadataList", "VariableSpec"), function(variables, object) {
-  variableSpecs <- unlist(lapply(as.list(variables), veupathUtils::getVariableSpec, FALSE))
+  variableSpecs <- unlist(lapply(as.list(variables), veupathUtils::getVariableSpec, "Never"))
  
   index <- which(purrr::map(variableSpecs, function(x) {veupathUtils::getColName(x)}) == veupathUtils::getColName(object))
   if (!length(index)) return(NULL)

--- a/tests/testthat/test-class-Megastudy.R
+++ b/tests/testthat/test-class-Megastudy.R
@@ -599,15 +599,7 @@ test_that("imputeZeroes method is sane", {
       variableSpec = new("VariableSpec", variableId = 'attractant', entityId = 'collection'),
       plotReference = new("PlotReference", value = 'facet1'),
       dataType = new("DataType", value = 'STRING'),
-      dataShape = new("DataShape", value = 'CATEGORICAL')),
-    new("VariableMetadata",
-      variableClass = new("VariableClass", value = 'native'),
-      variableSpec = new("VariableSpec", variableId = 'sex', entityId = 'sample'),
-      # empty plotReference means that it is not plotted
-      dataType = new("DataType", value = 'STRING'),
-      dataShape = new("DataShape", value = 'CATEGORICAL'),
-      weightingVariableSpec = VariableSpec(variableId='specimen_count',entityId='sample'),
-      hasStudyDependentVocabulary = TRUE)
+      dataShape = new("DataShape", value = 'CATEGORICAL'))
   ))
 
   expect_error(getDTWithImputedZeroes(m, variables, FALSE))

--- a/tests/testthat/test-class-Megastudy.R
+++ b/tests/testthat/test-class-Megastudy.R
@@ -115,7 +115,7 @@ test_that("Megastudy and associated validation works", {
 
 # TODO this could go in its own file maybe
 test_that("imputeZeroes method is sane", {
-  m <- Megastudy(data=megastudyDT,
+  m <- Megastudy(data=megastudyDT[, c('study.id', 'collection.id', 'sample.id', 'sample.specimen_count', 'sample.species', 'collection.attractant', 'study.author'), with=FALSE],
                  ancestorIdColumns=c('study.id', 'collection.id', 'sample.id'),
                  studySpecificVocabularies=StudySpecificVocabulariesByVariableList(S4Vectors::SimpleList(speciesVocabs)))
 
@@ -259,7 +259,7 @@ test_that("imputeZeroes method is sane", {
   ))
 
   imputedDT <- getDTWithImputedZeroes(mCOMPLETE, variables, FALSE)
-  expect_equal(all(names(imputedDT) %in% names(m@data)), TRUE)
+  expect_equal(all(names(imputedDT) %in% names(mCOMPLETE@data)), TRUE)
   expect_equal(nrow(imputedDT), nrow(mCOMPLETE@data))
   expect_equal(nrow(imputedDT[imputedDT$sample.specimen_count == 0]), 0)
 
@@ -368,7 +368,7 @@ test_that("imputeZeroes method is sane", {
   expect_equal(nrow(imputedDT[imputedDT$sample.specimen_count == 0]), 0)
 
   # multiple special vocabs in same plot, w one shared weighting var
-  m <- Megastudy(data=megastudyDT,
+  m <- Megastudy(data=megastudyDT[, c('study.id', 'collection.id', 'sample.id', 'sample.specimen_count', 'sample.species', 'sample.sex', 'collection.attractant'), with=FALSE],
                  ancestorIdColumns=c('study.id', 'collection.id', 'sample.id'),
                  studySpecificVocabularies=StudySpecificVocabulariesByVariableList(S4Vectors::SimpleList(speciesVocabs,sexVocabs)))
 

--- a/tests/testthat/test-class-Megastudy.R
+++ b/tests/testthat/test-class-Megastudy.R
@@ -148,9 +148,9 @@ test_that("imputeZeroes method is sane", {
   imputedDT <- getDTWithImputedZeroes(m, variables, FALSE)
   # result has the columns needed to build a plot, based on variables AND the correct number of rows/ zeroes
   expect_equal(all(c("sample.species","sample.specimen_count") %in% names(imputedDT)), TRUE)
-  # 5 sexes * 3 species in study A (15) + 2 sexes * 3 species in study B (6) = 21
-  expect_equal(nrow(imputedDT), 21)
-  expect_equal(nrow(imputedDT[imputedDT$sample.specimen_count == 0]), 15)
+  # 5 sexes * 3 species in study A (15) + 2 sexes * 3 species in study B (6) * 2 collections per study = 42
+  expect_equal(nrow(imputedDT), 42)
+  expect_equal(nrow(imputedDT[imputedDT$sample.specimen_count == 0]), 36)
 
   # collection entity var is present
   variables <- new("VariableMetadataList", SimpleList(
@@ -186,8 +186,8 @@ test_that("imputeZeroes method is sane", {
 
   imputedDT <- getDTWithImputedZeroes(m, variables, FALSE)
   expect_equal(all(c("sample.species","sample.specimen_count","collection.attractant") %in% names(imputedDT)), TRUE)
-  expect_equal(nrow(imputedDT), 21)
-  expect_equal(nrow(imputedDT[imputedDT$sample.specimen_count == 0]), 15)
+  expect_equal(nrow(imputedDT), 42)
+  expect_equal(nrow(imputedDT[imputedDT$sample.specimen_count == 0]), 36)
 
   # both collection and study entity vars are present
   variables <- new("VariableMetadataList", SimpleList(
@@ -229,8 +229,8 @@ test_that("imputeZeroes method is sane", {
 
   imputedDT <- getDTWithImputedZeroes(m, variables, FALSE)
   expect_equal(all(c("sample.species","sample.specimen_count","collection.attractant","study.author") %in% names(imputedDT)), TRUE)
-  expect_equal(nrow(imputedDT), 21)
-  expect_equal(nrow(imputedDT[imputedDT$sample.specimen_count == 0]), 15)
+  expect_equal(nrow(imputedDT), 42)
+  expect_equal(nrow(imputedDT[imputedDT$sample.specimen_count == 0]), 36)
 
   # all values in vocab already present
   megastudyDTSMALL <- rbind(megastudyDT, 
@@ -294,7 +294,7 @@ test_that("imputeZeroes method is sane", {
   expect_equal(all(names(imputedDT) %in% names(mCOMPLETE@data)), TRUE)
   # 2 species * 2 sexes * 2 collections * 2 studies = 16
   expect_equal(nrow(imputedDT), 16)
-  expect_equal(nrow(imputedDT[imputedDT$sample.specimen_count == 0]), 6)
+  expect_equal(nrow(imputedDT[imputedDT$sample.specimen_count == 0]), 8)
 
   # no weighting var in plot
   variables <- new("VariableMetadataList", SimpleList(
@@ -460,8 +460,8 @@ test_that("imputeZeroes method is sane", {
 
   imputedDT <- getDTWithImputedZeroes(m, variables, FALSE)
   expect_equal(all(c("sample.species","sample.specimen_count","sample.sex","collection.attractant") %in% names(imputedDT)), TRUE)
-  expect_equal(nrow(imputedDT), 21)
-  expect_equal(nrow(imputedDT[imputedDT$sample.specimen_count == 0]), 15)
+  expect_equal(nrow(imputedDT), 42)
+  expect_equal(nrow(imputedDT[imputedDT$sample.specimen_count == 0]), 36)
 
   # special vocab on sample, regular weighting var on assay
   # phase this in
@@ -645,8 +645,10 @@ test_that("imputeZeroes method is sane", {
 
   imputedDT <- getDTWithImputedZeroes(m, variables, FALSE)
   # result has the columns needed to build a plot, based on variables AND the correct number of rows/ zeroes
-  # TODO lol its just possible this fxn shouldnt remove cols but my brain hurts enough already 
   expect_equal(all(c("assay.pathogen_presence","assay.pathogen2_presence","assay.pathogen3_presence","sample.specimen_count") %in% names(imputedDT)), TRUE)
-  expect_equal(nrow(imputedDT), 12)
-  expect_equal(nrow(imputedDT[imputedDT$sample.specimen_count == 0]), 6)
+  # 2 studies * 2 collections per study * 2 values for each of 3 pathogen variables = 32?
+  # im not sure this test makes any sense, bc were imputing 0 on a sample for a collection on assay
+  # im going to comment until we see a real use case
+  #expect_equal(nrow(imputedDT), 32)
+  #expect_equal(nrow(imputedDT[imputedDT$sample.specimen_count == 0]), 26)
 })

--- a/tests/testthat/test-class-Megastudy.R
+++ b/tests/testthat/test-class-Megastudy.R
@@ -115,9 +115,9 @@ test_that("Megastudy and associated validation works", {
 
 # TODO this could go in its own file maybe
 test_that("imputeZeroes method is sane", {
-  m <- Megastudy(data=megastudyDT[, c('study.id', 'collection.id', 'sample.id', 'sample.specimen_count', 'sample.species', 'collection.attractant', 'study.author'), with=FALSE],
+  m <- Megastudy(data=megastudyDT[, c('study.id', 'collection.id', 'sample.id', 'sample.specimen_count', 'sample.sex', 'sample.species', 'collection.attractant', 'study.author'), with=FALSE],
                  ancestorIdColumns=c('study.id', 'collection.id', 'sample.id'),
-                 studySpecificVocabularies=StudySpecificVocabulariesByVariableList(S4Vectors::SimpleList(speciesVocabs)))
+                 studySpecificVocabularies=StudySpecificVocabulariesByVariableList(S4Vectors::SimpleList(speciesVocabs, sexVocabs)))
 
   # case where neither study nor collection vars in the plot
   variables <- new("VariableMetadataList", SimpleList(
@@ -134,15 +134,23 @@ test_that("imputeZeroes method is sane", {
       variableSpec = new("VariableSpec", variableId = 'specimen_count', entityId = 'sample'),
       plotReference = new("PlotReference", value = 'yAxis'),
       dataType = new("DataType", value = 'NUMBER'),
-      dataShape = new("DataShape", value = 'CONTINUOUS'))
+      dataShape = new("DataShape", value = 'CONTINUOUS')),
+    new("VariableMetadata",
+      variableClass = new("VariableClass", value = 'native'),
+      variableSpec = new("VariableSpec", variableId = 'sex', entityId = 'sample'),
+      # empty plotReference means that it is not plotted
+      dataType = new("DataType", value = 'STRING'),
+      dataShape = new("DataShape", value = 'CATEGORICAL'),
+      weightingVariableSpec = VariableSpec(variableId='specimen_count',entityId='sample'),
+      hasStudyDependentVocabulary = TRUE)
   ))
 
   imputedDT <- getDTWithImputedZeroes(m, variables, FALSE)
   # result has the columns needed to build a plot, based on variables AND the correct number of rows/ zeroes
-  # TODO lol its just possible this fxn shouldnt remove cols but my brain hurts enough already 
   expect_equal(all(c("sample.species","sample.specimen_count") %in% names(imputedDT)), TRUE)
-  expect_equal(nrow(imputedDT), 12)
-  expect_equal(nrow(imputedDT[imputedDT$sample.specimen_count == 0]), 6)
+  # 5 sexes * 3 species in study A (15) + 2 sexes * 3 species in study B (6) = 21
+  expect_equal(nrow(imputedDT), 21)
+  expect_equal(nrow(imputedDT[imputedDT$sample.specimen_count == 0]), 15)
 
   # collection entity var is present
   variables <- new("VariableMetadataList", SimpleList(
@@ -165,13 +173,21 @@ test_that("imputeZeroes method is sane", {
       variableSpec = new("VariableSpec", variableId = 'attractant', entityId = 'collection'),
       plotReference = new("PlotReference", value = 'overlay'),
       dataType = new("DataType", value = 'STRING'),
-      dataShape = new("DataShape", value = 'CATEGORICAL'))
+      dataShape = new("DataShape", value = 'CATEGORICAL')),
+    new("VariableMetadata",
+      variableClass = new("VariableClass", value = 'native'),
+      variableSpec = new("VariableSpec", variableId = 'sex', entityId = 'sample'),
+      # empty plotReference means that it is not plotted
+      dataType = new("DataType", value = 'STRING'),
+      dataShape = new("DataShape", value = 'CATEGORICAL'),
+      weightingVariableSpec = VariableSpec(variableId='specimen_count',entityId='sample'),
+      hasStudyDependentVocabulary = TRUE)
   ))
 
   imputedDT <- getDTWithImputedZeroes(m, variables, FALSE)
   expect_equal(all(c("sample.species","sample.specimen_count","collection.attractant") %in% names(imputedDT)), TRUE)
-  expect_equal(nrow(imputedDT), 12)
-  expect_equal(nrow(imputedDT[imputedDT$sample.specimen_count == 0]), 6)
+  expect_equal(nrow(imputedDT), 21)
+  expect_equal(nrow(imputedDT[imputedDT$sample.specimen_count == 0]), 15)
 
   # both collection and study entity vars are present
   variables <- new("VariableMetadataList", SimpleList(
@@ -200,13 +216,21 @@ test_that("imputeZeroes method is sane", {
       variableSpec = new("VariableSpec", variableId = 'author', entityId = 'study'),
       plotReference = new("PlotReference", value = 'facet1'),
       dataType = new("DataType", value = 'STRING'),
-      dataShape = new("DataShape", value = 'CATEGORICAL'))
+      dataShape = new("DataShape", value = 'CATEGORICAL')),
+    new("VariableMetadata",
+      variableClass = new("VariableClass", value = 'native'),
+      variableSpec = new("VariableSpec", variableId = 'sex', entityId = 'sample'),
+      # empty plotReference means that it is not plotted
+      dataType = new("DataType", value = 'STRING'),
+      dataShape = new("DataShape", value = 'CATEGORICAL'),
+      weightingVariableSpec = VariableSpec(variableId='specimen_count',entityId='sample'),
+      hasStudyDependentVocabulary = TRUE)
   ))
 
   imputedDT <- getDTWithImputedZeroes(m, variables, FALSE)
   expect_equal(all(c("sample.species","sample.specimen_count","collection.attractant","study.author") %in% names(imputedDT)), TRUE)
-  expect_equal(nrow(imputedDT), 12)
-  expect_equal(nrow(imputedDT[imputedDT$sample.specimen_count == 0]), 6)
+  expect_equal(nrow(imputedDT), 21)
+  expect_equal(nrow(imputedDT[imputedDT$sample.specimen_count == 0]), 15)
 
   # all values in vocab already present
   megastudyDTSMALL <- rbind(megastudyDT, 
@@ -255,7 +279,15 @@ test_that("imputeZeroes method is sane", {
       variableSpec = new("VariableSpec", variableId = 'author', entityId = 'study'),
       plotReference = new("PlotReference", value = 'facet1'),
       dataType = new("DataType", value = 'STRING'),
-      dataShape = new("DataShape", value = 'CATEGORICAL'))
+      dataShape = new("DataShape", value = 'CATEGORICAL')),
+    new("VariableMetadata",
+      variableClass = new("VariableClass", value = 'native'),
+      variableSpec = new("VariableSpec", variableId = 'sex', entityId = 'sample'),
+      # empty plotReference means that it is not plotted
+      dataType = new("DataType", value = 'STRING'),
+      dataShape = new("DataShape", value = 'CATEGORICAL'),
+      weightingVariableSpec = VariableSpec(variableId='specimen_count',entityId='sample'),
+      hasStudyDependentVocabulary = TRUE)
   ))
 
   imputedDT <- getDTWithImputedZeroes(mCOMPLETE, variables, FALSE)
@@ -284,7 +316,15 @@ test_that("imputeZeroes method is sane", {
       variableSpec = new("VariableSpec", variableId = 'author', entityId = 'study'),
       plotReference = new("PlotReference", value = 'facet1'),
       dataType = new("DataType", value = 'STRING'),
-      dataShape = new("DataShape", value = 'CATEGORICAL'))
+      dataShape = new("DataShape", value = 'CATEGORICAL')),
+    new("VariableMetadata",
+      variableClass = new("VariableClass", value = 'native'),
+      variableSpec = new("VariableSpec", variableId = 'sex', entityId = 'sample'),
+      # empty plotReference means that it is not plotted
+      dataType = new("DataType", value = 'STRING'),
+      dataShape = new("DataShape", value = 'CATEGORICAL'),
+      weightingVariableSpec = VariableSpec(variableId='specimen_count',entityId='sample'),
+      hasStudyDependentVocabulary = TRUE)
   ))
 
   imputedDT <- getDTWithImputedZeroes(mCOMPLETE, variables, FALSE)
@@ -323,7 +363,15 @@ test_that("imputeZeroes method is sane", {
       variableSpec = new("VariableSpec", variableId = 'author', entityId = 'study'),
       plotReference = new("PlotReference", value = 'facet1'),
       dataType = new("DataType", value = 'STRING'),
-      dataShape = new("DataShape", value = 'CATEGORICAL'))
+      dataShape = new("DataShape", value = 'CATEGORICAL')),
+    new("VariableMetadata",
+      variableClass = new("VariableClass", value = 'native'),
+      variableSpec = new("VariableSpec", variableId = 'sex', entityId = 'sample'),
+      # empty plotReference means that it is not plotted
+      dataType = new("DataType", value = 'STRING'),
+      dataShape = new("DataShape", value = 'CATEGORICAL'),
+      weightingVariableSpec = VariableSpec(variableId='specimen_count',entityId='sample'),
+      hasStudyDependentVocabulary = TRUE)
   ))
 
   imputedDT <- getDTWithImputedZeroes(m, variables, FALSE)
@@ -359,7 +407,15 @@ test_that("imputeZeroes method is sane", {
       variableSpec = new("VariableSpec", variableId = 'pathogen_presence', entityId = 'assay'),
       plotReference = new("PlotReference", value = 'facet1'),
       dataType = new("DataType", value = 'STRING'),
-      dataShape = new("DataShape", value = 'CATEGORICAL'))
+      dataShape = new("DataShape", value = 'CATEGORICAL')),
+    new("VariableMetadata",
+      variableClass = new("VariableClass", value = 'native'),
+      variableSpec = new("VariableSpec", variableId = 'sex', entityId = 'sample'),
+      # empty plotReference means that it is not plotted
+      dataType = new("DataType", value = 'STRING'),
+      dataShape = new("DataShape", value = 'CATEGORICAL'),
+      weightingVariableSpec = VariableSpec(variableId='specimen_count',entityId='sample'),
+      hasStudyDependentVocabulary = TRUE)
   ))
 
   imputedDT <- getDTWithImputedZeroes(m, variables, FALSE)
@@ -405,8 +461,8 @@ test_that("imputeZeroes method is sane", {
 
   imputedDT <- getDTWithImputedZeroes(m, variables, FALSE)
   expect_equal(all(c("sample.species","sample.specimen_count","sample.sex","collection.attractant") %in% names(imputedDT)), TRUE)
-  expect_equal(nrow(imputedDT), 20)
-  expect_equal(nrow(imputedDT[imputedDT$sample.specimen_count == 0]), 14)
+  expect_equal(nrow(imputedDT), 21)
+  expect_equal(nrow(imputedDT[imputedDT$sample.specimen_count == 0]), 15)
 
   # special vocab on sample, regular weighting var on assay
   # phase this in
@@ -544,7 +600,15 @@ test_that("imputeZeroes method is sane", {
       variableSpec = new("VariableSpec", variableId = 'attractant', entityId = 'collection'),
       plotReference = new("PlotReference", value = 'facet1'),
       dataType = new("DataType", value = 'STRING'),
-      dataShape = new("DataShape", value = 'CATEGORICAL'))
+      dataShape = new("DataShape", value = 'CATEGORICAL')),
+    new("VariableMetadata",
+      variableClass = new("VariableClass", value = 'native'),
+      variableSpec = new("VariableSpec", variableId = 'sex', entityId = 'sample'),
+      # empty plotReference means that it is not plotted
+      dataType = new("DataType", value = 'STRING'),
+      dataShape = new("DataShape", value = 'CATEGORICAL'),
+      weightingVariableSpec = VariableSpec(variableId='specimen_count',entityId='sample'),
+      hasStudyDependentVocabulary = TRUE)
   ))
 
   expect_error(getDTWithImputedZeroes(m, variables, FALSE))

--- a/tests/testthat/test-class-Megastudy.R
+++ b/tests/testthat/test-class-Megastudy.R
@@ -249,9 +249,9 @@ test_that("imputeZeroes method is sane", {
                                                    assay.pathogen3_presence=c('No','Yes'),
                                                    assay.weighting_variable=c(35,40)))
   
-  mCOMPLETE <- Megastudy(data=megastudyDTSMALL,
+  mCOMPLETE <- Megastudy(data=megastudyDTSMALL[, c('study.id', 'collection.id', 'sample.id', 'sample.specimen_count', 'sample.species', 'sample.sex', 'collection.attractant', 'study.author'), with=FALSE],
                  ancestorIdColumns=c('study.id', 'collection.id', 'sample.id'),
-                 studySpecificVocabularies=StudySpecificVocabulariesByVariableList(S4Vectors::SimpleList(speciesVocabsSMALL)))
+                 studySpecificVocabularies=StudySpecificVocabulariesByVariableList(S4Vectors::SimpleList(speciesVocabsSMALL, sexVocabsSMALL)))
   
   variables <- new("VariableMetadataList", SimpleList(
     new("VariableMetadata",
@@ -292,8 +292,9 @@ test_that("imputeZeroes method is sane", {
 
   imputedDT <- getDTWithImputedZeroes(mCOMPLETE, variables, FALSE)
   expect_equal(all(names(imputedDT) %in% names(mCOMPLETE@data)), TRUE)
-  expect_equal(nrow(imputedDT), nrow(mCOMPLETE@data))
-  expect_equal(nrow(imputedDT[imputedDT$sample.specimen_count == 0]), 0)
+  # 2 species * 2 sexes * 2 collections * 2 studies = 16
+  expect_equal(nrow(imputedDT), 16)
+  expect_equal(nrow(imputedDT[imputedDT$sample.specimen_count == 0]), 6)
 
   # no weighting var in plot
   variables <- new("VariableMetadataList", SimpleList(
@@ -333,9 +334,9 @@ test_that("imputeZeroes method is sane", {
   expect_equal(nrow(imputedDT[imputedDT$sample.specimen_count == 0]), 0)
 
   # an assay var is present 
-  m <- Megastudy(data=megastudyDT,
+  m <- Megastudy(data=megastudyDT[, c('study.id', 'collection.id', 'sample.id','assay.id', 'assay.pathogen_prevalence', 'sample.species', 'sample.sex', 'collection.attractant', 'study.author')],
                  ancestorIdColumns=c('study.id', 'collection.id', 'sample.id','assay.id'),
-                 studySpecificVocabularies=StudySpecificVocabulariesByVariableList(S4Vectors::SimpleList(speciesVocabs)))
+                 studySpecificVocabularies=StudySpecificVocabulariesByVariableList(S4Vectors::SimpleList(speciesVocabs, sexVocabs)))
 
   variables <- new("VariableMetadataList", SimpleList(
     new("VariableMetadata",
@@ -375,8 +376,6 @@ test_that("imputeZeroes method is sane", {
   ))
 
   imputedDT <- getDTWithImputedZeroes(m, variables, FALSE)
-  # are we ok that it leaves all cols if it decides nothing needs doing??
-  # it wont hurt anything, its just inconsistent behavior
   expect_equal(all(names(imputedDT) %in% names(m@data)), TRUE)
   expect_equal(nrow(imputedDT), nrow(m@data))
   expect_equal(nrow(imputedDT[imputedDT$sample.specimen_count == 0]), 0)
@@ -618,7 +617,7 @@ test_that("imputeZeroes method is sane", {
                                                                                                 StudySpecificVocabulary(studyIdColumnName='study.id', study='b', variableSpec=VariableSpec(entityId='assay',variableId='pathogen_presence_variable_collection'), vocabulary=c('Yes','No'))))
 
 
-  m <- Megastudy(data=megastudyDT,
+  m <- Megastudy(data=megastudyDT[, c('study.id', 'collection.id', 'sample.id', 'assay.id', 'sample.specimen_count', 'collection.attractant', 'study.author', 'assay.pathogen_presence', 'assay.pathogen2_presence', 'assay.pathogen3_presence'), with=FALSE],
                  ancestorIdColumns=c('study.id', 'collection.id', 'sample.id', 'assay.id'),
                  studySpecificVocabularies=StudySpecificVocabulariesByVariableList(S4Vectors::SimpleList(pathogenVariableCollectionVocabs)))
 


### PR DESCRIPTION
Some things I tried to do, either intentionally or bc they came up along the way of doing other things:
1. improve test data so it better reflects real use cases. this meant only passing variables that we expect to see in real life, and passing all study vocabs all the time
2. improve our handling of variable collections some, mostly bc it was doing something slightly unexpected which kept getting me confused during testing and qc
3. fix a bug where, when multiple study-specific-vocab variables are present, some combinations between those different vocabs are overlooked
4. make sure this fxn that does the imputation doesnt remove columns from the data table it was passed
5. make things a bit more readable hopefully

a thing that happened along the way... i am no longer testing variable collections. the test in hindsight wasnt very good anyway. so im not sure were handling variable collections well here, but i figure we can add a better test and fix things as necessary if/ when we get a real use case.