### PR TITLE
fill computationDetails for correlation compute results

### DIFF
--- a/R/method-correlation.R
+++ b/R/method-correlation.R
@@ -130,6 +130,7 @@ function(data1, data2, method = c('spearman','pearson'), format = c('ComputeResu
     return(formattedCorrResult)
   } else {
     result <- buildCorrelationComputeResult(formattedCorrResult, data1, data2, method, verbose)
+    result@computationDetails <- 'correlation'
     return(result)
   }
 })
@@ -205,6 +206,7 @@ function(data1, data2, method = c('spearman','pearson','sparcc'), format = c('Co
     return(formattedCorrResult)
   } else {
     result <- buildCorrelationComputeResult(formattedCorrResult, data1, data2, method, verbose)
+    result@computationDetails <- 'selfCorrelation'
     return(result)
   }
 })


### PR DESCRIPTION
id like to track when a correlation was a self correlation or not, within the ComputeResult object. thatd help me downstream in the new mbio r package. im using here the computationDetails slot for this purpose, which was previously unpopulated.