### PR TITLE
warning rather than error for non-cont vars in correlation inputs

### DIFF
--- a/R/method-correlation.R
+++ b/R/method-correlation.R
@@ -114,11 +114,17 @@ function(
   if (!identical(veupathUtils::findNumericCols(data1), names(data1))) { 
     warning("All columns in data1 are not numeric. Only numeric columns will be used.")
     keepCols <- veupathUtils::findNumericCols(data1)
+    if (length(keepCols) == 0) {
+      stop("No numeric columns found in data1.")
+    }
     data1 <- data1[, ..keepCols]
   }
   if (!identical(veupathUtils::findNumericCols(data2), names(data2))) { 
     warning("All columns in data2 are not numeric. Only numeric columns will be used.")
     keepCols <- veupathUtils::findNumericCols(data2)
+    if (length(keepCols) == 0) {
+      stop("No numeric columns found in data2.")
+    }
     data2 <- data2[, ..keepCols]
   }
 
@@ -186,6 +192,9 @@ function(
   if (!identical(veupathUtils::findNumericCols(data1), names(data1))) { 
     warning("All columns in data1 are not numeric. Only numeric columns will be used.")
     keepCols <- veupathUtils::findNumericCols(data1)
+    if (length(keepCols) == 0) {
+      stop("No numeric columns found in data1.")
+    }
     data1 <- data1[, ..keepCols]
   }
 

--- a/R/method-correlation.R
+++ b/R/method-correlation.R
@@ -111,8 +111,16 @@ function(
   }
 
   # Check that all values are numeric
-  if (!identical(veupathUtils::findNumericCols(data1), names(data1))) { stop("All columns in data1 must be numeric.")}
-  if (!identical(veupathUtils::findNumericCols(data2), names(data2))) { stop("All columns in data2 must be numeric.")}
+  if (!identical(veupathUtils::findNumericCols(data1), names(data1))) { 
+    warning("All columns in data1 are not numeric. Only numeric columns will be used.")
+    keepCols <- veupathUtils::findNumericCols(data1)
+    data1 <- data1[, ..keepCols]
+  }
+  if (!identical(veupathUtils::findNumericCols(data2), names(data2))) { 
+    warning("All columns in data2 are not numeric. Only numeric columns will be used.")
+    keepCols <- veupathUtils::findNumericCols(data2)
+    data2 <- data2[, ..keepCols]
+  }
 
 
   ## Compute correlation
@@ -175,7 +183,11 @@ function(
   verbose <- veupathUtils::matchArg(verbose)
 
   # Check that all values are numeric
-  if (!identical(veupathUtils::findNumericCols(data1), names(data1))) { stop("All columns in data1 must be numeric.")}
+  if (!identical(veupathUtils::findNumericCols(data1), names(data1))) { 
+    warning("All columns in data1 are not numeric. Only numeric columns will be used.")
+    keepCols <- veupathUtils::findNumericCols(data1)
+    data1 <- data1[, ..keepCols]
+  }
 
   ## Compute correlation
   # rownames and colnames should be the same in this case


### PR DESCRIPTION
requested by dan, seems reasonable. should still err if it has ONLY cat vars.